### PR TITLE
Add Vercel webhook handler (api/webhook.ts) and listener updates

### DIFF
--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -1,0 +1,34 @@
+// Vercel / Next.js Serverless API handler
+// Deploy this file to your Vercel project under /api/webhook
+import { VercelRequest, VercelResponse } from '@vercel/node';
+
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
+const MODE = process.env.MODE || 'paper';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const auth = req.headers.authorization;
+  if (!WEBHOOK_SECRET || auth !== `Bearer ${WEBHOOK_SECRET}`) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  try {
+    const payload = req.body;
+    const { eventType, signature, slot, txSummary } = payload || {};
+    if (!eventType || !signature) return res.status(400).json({ error: 'invalid_payload' });
+
+    if (MODE === 'paper') {
+      console.log(`[PAPER] ${eventType} - ${signature} slot:${slot}`, txSummary ? { fee: txSummary.fee } : null);
+      // simulate logic here
+    } else {
+      console.log(`[LIVE] ${eventType} - queued for execution`, signature);
+      // enqueue real execution (not implemented here)
+    }
+
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error('webhook handler error', err);
+    return res.status(500).json({ error: 'internal_error' });
+  }
+}

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -15,6 +15,7 @@ import { Connection, PublicKey } from '@solana/web3.js';
  * - MAX_GETTX_PER_SEC (default 5)
  * - CONFIRMATIONS (optional)
  */
+
 const RPC_WSS = process.env.RPC_WSS!;
 const WEBHOOK_URL = process.env.WEBHOOK_URL!;
 const WEBHOOK_AUTH = process.env.WEBHOOK_AUTH ? `Bearer ${process.env.WEBHOOK_AUTH}` : undefined;


### PR DESCRIPTION
 Fügt einen Vercel Serverless API Endpoint unter api/webhook.ts hinzu. Nutze diesen Endpoint als öffentliches WEBHOOK Ziel. WICHTIG: Keine Secrets in das Repo committen. Setze WEBHOOK_SECRET in Vercel Environment Variables.